### PR TITLE
I guess it's a typo

### DIFF
--- a/cryptoconditions.py
+++ b/cryptoconditions.py
@@ -10,7 +10,7 @@ from ctypes import *
 
 
 so = cdll.LoadLibrary('.libs/libcryptoconditions.so')
-so.jsonRPC.restype = c_char_p
+so.cc_jsonRPC.restype = c_char_p
 
 
 def jsonRPC(method, params, load=True):


### PR DESCRIPTION
Current cryptoconditions.py throwing an error on execution:
```
./cryptoconditions.py --help
Traceback (most recent call last):
  File "./cryptoconditions.py", line 13, in <module>
    so.cJSON.restype = c_char_p
  File "/usr/lib/python2.7/ctypes/__init__.py", line 379, in __getattr__
    func = self.__getitem__(name)
  File "/usr/lib/python2.7/ctypes/__init__.py", line 384, in __getitem__
    func = self._FuncPtr((name_or_ordinal, self))
AttributeError: .libs/libcryptoconditions.so: undefined symbol: cJSON
```
This change fixed it for me